### PR TITLE
Prevent text overlapping with image

### DIFF
--- a/src/components/Menu/styles.css
+++ b/src/components/Menu/styles.css
@@ -3,7 +3,6 @@
   font: 14px/1.5 "Noto Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
   flex-direction: column;
   margin-bottom: 30px;
-  height: 570px;
   -webkit-font-smoothing: subpixel-antialiased;
 }
 


### PR DESCRIPTION
Bug occurs on screen sizes between 450px and 750px.

![image](https://user-images.githubusercontent.com/4342234/110190205-ea3e8e00-7e00-11eb-91be-4f2a6346a0b4.png)
